### PR TITLE
Artifacts dir support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 go.work
 go.work.sum
 .claude/settings.local.json
+.claude/CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Flume is a Go structured logging library. This is a multi-version monorepo:
+- **Root directory**: Flume v1 (built on `go.uber.org/zap`)
+- **v2/ directory**: Flume v2 (ground-up rewrite as a `slog.Handler`, minimal dependencies)
+- **go.work**: Ties both modules together as a Go workspace
+
+v2 is actively developed and near release. v1 is mature/legacy.
+
+## Build Commands
+
+### v1 (root directory, uses Make)
+
+| Task | Command |
+|------|---------|
+| All | `make all` |
+| Build | `make build` |
+| Test | `make test` |
+| Lint | `make lint` |
+| Format | `make fmt` |
+| Coverage | `make cover` (output: `build/coverage.html`) |
+
+### v2 (v2/ directory, uses just)
+
+| Task | Command |
+|------|---------|
+| All | `just all` |
+| Build | `just build` |
+| Test | `just test` |
+| Single test | `just tests -run TestName` |
+| Lint | `just lint` |
+| Format | `just fmt` |
+| Coverage | `just cover` (output: `build/coverage.html`) |
+
+Both use `go test -race` by default. Linting uses `golangci-lint`.
+
+## Architecture
+
+### v2 Core (primary development target)
+
+- **`handler.go`**: Core `Handler` type implementing `slog.Handler`. Wraps an inner handler with atomic swapping for runtime reconfiguration.
+- **`handler_options.go`**: `HandlerOptions` config and factory functions (`NewHandler`, `NewJSONHandler`, `NewTextHandler`, etc.).
+- **`default.go`**: Global default handler singleton.
+- **`middleware.go`**: Middleware chain support for processing log records.
+- **`config_from_env.go`**: Configuration via `FLUME` environment variable (JSON or levels string).
+- **`adapter.go`**: Bridge between slog and zap cores (for v1 interop).
+- **`v1_compat.go`**: v1 compatibility layer and migration tools.
+- **`flumetest/`**: Test helpers for capturing/asserting log output.
+
+### Key Design Principles
+
+- **Silent by default**: Logs are discarded unless explicitly configured (library-friendly).
+- **Named loggers**: Per-logger level configuration via a `logger` attribute key.
+- **Thread-safe**: Atomic handler swapping for runtime reconfiguration.
+- **Context integration**: Loggers bound to `context.Context`.
+
+### Handler Types
+
+`TextHandler`, `JSONHandler`, `TermHandler`, `TermColorHandler`, `NoopHandler`
+
+## Testing
+
+- Uses `github.com/stretchr/testify` for assertions.
+- Both modules require Go 1.21+.
+- CI tests against multiple Go versions (oldstable, stable).
+
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,71 +1,13 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+The role of this file is to describe common mistakes and confusion points that
+agents might encounter as they work in this project.  If you ever encounter
+something in the project that surprises you, please alert the developer working
+with you and indicate that this is the case in the AgentMD file to help prevent
+future agents from having the same issue.
 
-## Project Overview
-
-Flume is a Go structured logging library. This is a multi-version monorepo:
-- **Root directory**: Flume v1 (built on `go.uber.org/zap`)
-- **v2/ directory**: Flume v2 (ground-up rewrite as a `slog.Handler`, minimal dependencies)
-- **go.work**: Ties both modules together as a Go workspace
-
-v2 is actively developed and near release. v1 is mature/legacy.
-
-## Build Commands
-
-### v1 (root directory, uses Make)
-
-| Task | Command |
-|------|---------|
-| All | `make all` |
-| Build | `make build` |
-| Test | `make test` |
-| Lint | `make lint` |
-| Format | `make fmt` |
-| Coverage | `make cover` (output: `build/coverage.html`) |
-
-### v2 (v2/ directory, uses just)
-
-| Task | Command |
-|------|---------|
-| All | `just all` |
-| Build | `just build` |
-| Test | `just test` |
-| Single test | `just tests -run TestName` |
-| Lint | `just lint` |
-| Format | `just fmt` |
-| Coverage | `just cover` (output: `build/coverage.html`) |
-
-Both use `go test -race` by default. Linting uses `golangci-lint`.
-
-## Architecture
-
-### v2 Core (primary development target)
-
-- **`handler.go`**: Core `Handler` type implementing `slog.Handler`. Wraps an inner handler with atomic swapping for runtime reconfiguration.
-- **`handler_options.go`**: `HandlerOptions` config and factory functions (`NewHandler`, `NewJSONHandler`, `NewTextHandler`, etc.).
-- **`default.go`**: Global default handler singleton.
-- **`middleware.go`**: Middleware chain support for processing log records.
-- **`config_from_env.go`**: Configuration via `FLUME` environment variable (JSON or levels string).
-- **`adapter.go`**: Bridge between slog and zap cores (for v1 interop).
-- **`v1_compat.go`**: v1 compatibility layer and migration tools.
-- **`flumetest/`**: Test helpers for capturing/asserting log output.
-
-### Key Design Principles
-
-- **Silent by default**: Logs are discarded unless explicitly configured (library-friendly).
-- **Named loggers**: Per-logger level configuration via a `logger` attribute key.
-- **Thread-safe**: Atomic handler swapping for runtime reconfiguration.
-- **Context integration**: Loggers bound to `context.Context`.
-
-### Handler Types
-
-`TextHandler`, `JSONHandler`, `TermHandler`, `TermColorHandler`, `NoopHandler`
-
-## Testing
-
-- Uses `github.com/stretchr/testify` for assertions.
-- Both modules require Go 1.21+.
-- CI tests against multiple Go versions (oldstable, stable).
-
-
+> **Instructions to developers (agents: ignore this)**
+> 
+> Review the changes the agent makes to this files.  This tells you things about 
+> this project which aren't friendly to the way agents work.  You should consider
+> adjusting the project to make the instructions here unnecessary.

--- a/core.go
+++ b/core.go
@@ -167,7 +167,7 @@ func (l *Core) sweetenFields(args []interface{}) []zap.Field {
 
 		// Consume this value and the next, treating them as a key-value pair. If the
 		// key isn't a string, add this pair to the slice of invalid pairs.
-		key, val := args[i], args[i+1]
+		key, val := args[i], args[i+1] //nolint:gosec // bounds checked above
 		if keyStr, ok := key.(string); !ok {
 			// Subsequent errors are likely, so allocate once up front.
 			if cap(invalid) == 0 {

--- a/v2/.claude/settings.local.json
+++ b/v2/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go vet:*)",
+      "Bash(go test:*)",
+      "Bash(go version:*)",
+      "Bash(go doc:*)",
+      "Bash(go help:*)",
+      "WebSearch"
+    ]
+  }
+}

--- a/v2/flumetest/artifacts.go
+++ b/v2/flumetest/artifacts.go
@@ -1,0 +1,183 @@
+package flumetest
+
+import (
+	"flag"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+)
+
+var (
+	artifactDirsMu sync.Mutex
+	artifactDirs   = make(map[testingTB]string)
+)
+
+func init() { //nolint:gochecknoinits
+	// Register -artifacts flag if go1.26 hasn't already done so.
+	if flag.CommandLine.Lookup("test.artifacts") == nil &&
+		flag.CommandLine.Lookup("artifacts") == nil {
+		flag.Bool("artifacts", false, "store test artifacts in test output dir")
+	}
+}
+
+func artifactLogFileName() string {
+	return "flumetest_" + time.Now().Format("20060102T150405.000") + ".log"
+}
+
+// artifactsEnabled checks whether the -artifacts flag was set to true.
+// Checks both "test.artifacts" (go1.26+ via `go test -artifacts`) and
+// "artifacts" (go1.25 and below, where `go test` passes unknown flags through as-is).
+func artifactsEnabled() bool {
+	for _, name := range []string{"test.artifacts", "artifacts"} {
+		if f := flag.CommandLine.Lookup(name); f != nil {
+			if f.Value.String() == "true" {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+type hasArtifactDir interface {
+	ArtifactDir() string
+}
+
+// getArtifactDir returns the artifact directory for t.
+// On go1.26+ it delegates to t.ArtifactDir(); on older versions it emulates
+// the same behavior using flag inspection and os.MkdirTemp.
+func getArtifactDir(t testingTB) (string, bool) {
+	// go1.26+ exposes ArtifactDir() on *testing.T.
+	if a, ok := t.(hasArtifactDir); ok {
+		return a.ArtifactDir(), true
+	}
+
+	if !artifactsEnabled() {
+		return "", false
+	}
+
+	artifactDirsMu.Lock()
+	defer artifactDirsMu.Unlock()
+
+	if dir, ok := artifactDirs[t]; ok {
+		return dir, true
+	}
+
+	// Get output dir from -test.outputdir flag, default to "."
+	outputDir := "."
+	if f := flag.CommandLine.Lookup("test.outputdir"); f != nil && f.Value.String() != "" {
+		outputDir = f.Value.String()
+	}
+
+	artifactDir := filepath.Join(outputDir, "_artifacts")
+
+	artifactBase := filepath.Join(artifactDir, relArtifactBase(t, debug.ReadBuildInfo))
+	if err := os.MkdirAll(artifactBase, 0o777); err != nil {
+		return "", false
+	}
+
+	dir, err := os.MkdirTemp(artifactBase, "")
+	if err != nil {
+		return "", false
+	}
+
+	// t.Output() added in 1.25
+	if tOutput, ok := t.(interface{ Output() io.Writer }); ok {
+		fmt.Fprintln(tOutput.Output(), "=== ARTIFACTS", t.Name(), dir)
+	} else {
+		t.Log("=== ARTIFACTS", t.Name(), dir)
+	}
+
+	artifactDirs[t] = dir
+
+	t.Cleanup(func() {
+		artifactDirsMu.Lock()
+		defer artifactDirsMu.Unlock()
+
+		delete(artifactDirs, t)
+	})
+
+	return dir, true
+}
+
+func relArtifactBase(t testingTB, readBuildInfo func() (*debug.BuildInfo, bool)) string {
+	name := t.Name()
+
+	// Sanitize name similarly to go1.26's makeArtifactDir
+	const maxNameSize = 64
+
+	safeName := strings.ReplaceAll(name, "/", "__")
+	if len(safeName) > maxNameSize {
+		h := fmt.Sprintf("%0x", hashName(name))
+		safeName = safeName[:maxNameSize-len(h)] + h
+	}
+
+	pkg := "unknown"
+	if info, ok := readBuildInfo(); ok && strings.HasSuffix(info.Path, ".test") {
+		pkg = strings.TrimSuffix(info.Path, ".test")
+		// trim module first, then leading slash.  if path == main.path
+		// we want to trim everything
+		pkg = strings.TrimPrefix(pkg, info.Main.Path)
+		pkg = strings.TrimPrefix(pkg, "/")
+	}
+
+	base := safeName
+	if pkg != "" {
+		base = pkg + "/" + safeName
+	}
+
+	base = removeSymbolsExcept(base, "!#$%&()+,-.=@^_ { } ~ /")
+
+	var err error
+
+	base, err = filepath.Localize(base)
+	if err != nil {
+		// This name can't be safely converted into a local filepath.
+		// Drop it and just use _artifacts/<random>.
+		base = ""
+	}
+
+	return base
+}
+
+func removeSymbolsExcept(s, allowed string) string {
+	mapper := func(r rune) rune {
+		if unicode.IsLetter(r) ||
+			unicode.IsNumber(r) ||
+			strings.ContainsRune(allowed, r) {
+			return r
+		}
+
+		return -1 // disallowed symbol
+	}
+
+	return strings.Map(mapper, s)
+}
+
+func hashName(name string) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(name))
+
+	return h.Sum64()
+}
+
+func openArtifactFile(t testingTB) *os.File {
+	dir, ok := getArtifactDir(t)
+	if !ok {
+		return nil
+	}
+
+	f, err := os.Create(filepath.Join(dir, artifactLogFileName()))
+	if err != nil {
+		return nil
+	}
+
+	return f
+}

--- a/v2/flumetest/artifacts_test.go
+++ b/v2/flumetest/artifacts_test.go
@@ -1,0 +1,402 @@
+package flumetest
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+	"testing"
+
+	"github.com/ThalesGroup/flume/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockTOldGo simulates *testing.T on pre-go1.26: provides Name() but not ArtifactDir().
+type mockTOldGo struct {
+	mockT
+
+	name string
+}
+
+func (m *mockTOldGo) Name() string { return m.name }
+
+// clearArtifactsFlag temporarily disables the artifacts flag for the duration of t,
+// regardless of how the test binary was invoked.
+func clearArtifactsFlag(t *testing.T) {
+	t.Helper()
+
+	for _, name := range []string{"test.artifacts", "artifacts"} {
+		if f := flag.CommandLine.Lookup(name); f != nil {
+			old := f.Value.String()
+
+			require.NoError(t, flag.CommandLine.Set(name, "false"))
+			t.Cleanup(func() { _ = flag.CommandLine.Set(name, old) })
+
+			return
+		}
+	}
+
+	t.Fatal("no artifacts flag found")
+}
+
+// setOutputDir temporarily points the test.outputdir flag at a fresh temp directory
+// for the duration of t, and returns that directory's path.  The test is skipped
+// if the flag is not registered in this binary.
+func setOutputDir(t *testing.T) string {
+	t.Helper()
+
+	f := flag.CommandLine.Lookup("test.outputdir")
+	if f == nil {
+		t.Skip("test.outputdir flag not registered in this test binary")
+	}
+
+	dir := t.TempDir()
+	old := f.Value.String()
+
+	require.NoError(t, flag.CommandLine.Set("test.outputdir", dir))
+	t.Cleanup(func() { _ = flag.CommandLine.Set("test.outputdir", old) })
+
+	return dir
+}
+
+// findArtifactLogRecursive walks baseDir and returns the single flumetest_*.log
+// file found anywhere beneath it.  Fails the test if there isn't exactly one.
+func findArtifactLogRecursive(t *testing.T, baseDir string) string {
+	t.Helper()
+
+	var found []string
+
+	err := filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() &&
+			strings.HasPrefix(d.Name(), "flumetest_") &&
+			strings.HasSuffix(d.Name(), ".log") {
+			found = append(found, path)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, found, 1, "expected exactly one artifact log file under %s", baseDir)
+
+	return found[0]
+}
+
+// assertNoArtifactLogs walks baseDir and fails the test if any flumetest_*.log
+// files are found.
+func assertNoArtifactLogs(t *testing.T, baseDir string) {
+	t.Helper()
+
+	var found []string
+
+	err := filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() &&
+			strings.HasPrefix(d.Name(), "flumetest_") &&
+			strings.HasSuffix(d.Name(), ".log") {
+			found = append(found, path)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Empty(t, found, "expected no artifact log files under %s", baseDir)
+}
+
+// mockTOldGoWithOutput simulates *testing.T on go1.25: provides Name() and Output() but not ArtifactDir().
+type mockTOldGoWithOutput struct {
+	mockTOldGo
+
+	output strings.Builder
+}
+
+func (m *mockTOldGoWithOutput) Output() io.Writer { return &m.output }
+
+// TestGetArtifactDir exercises the pre-go1.26 emulation paths in getArtifactDir:
+// artifact flag checks, name sanitisation, default name fallback, and long-name
+// truncation with a hash suffix.
+func TestGetArtifactDir(t *testing.T) {
+	t.Run("artifacts_disabled", func(t *testing.T) {
+		// No ArtifactDir() method and the -artifacts flag is not set.
+		clearArtifactsFlag(t)
+
+		m := &mockTOldGo{name: "SomeTest"}
+		dir, ok := getArtifactDir(m)
+		assert.False(t, ok)
+		assert.Empty(t, dir)
+	})
+
+	t.Run("with_name_creates_dir_inside_outputdir", func(t *testing.T) {
+		setArtifactsFlag(t)
+		outDir := setOutputDir(t)
+
+		m := &mockTOldGo{name: "TestGetArtifactDir/with_name"}
+		dir, ok := getArtifactDir(m)
+		require.True(t, ok)
+		assert.DirExists(t, dir)
+
+		// The returned dir must live inside outDir.
+		rel, err := filepath.Rel(outDir, dir)
+		require.NoError(t, err)
+		assert.False(t, strings.HasPrefix(rel, ".."), "dir should be inside outDir")
+
+		// The sanitised test name must appear as a path component.
+		assert.Contains(t, dir, "TestGetArtifactDir__with_name")
+	})
+
+	t.Run("nice_name_uses_name_as_prefix", func(t *testing.T) {
+		setArtifactsFlag(t)
+		outDir := setOutputDir(t)
+
+		m := &mockTOldGo{name: "NiceTestName"}
+		dir, ok := getArtifactDir(m)
+		require.True(t, ok)
+		assert.NotEmpty(t, dir)
+
+		// Should be created under outDir/_artifacts/flumetest/NiceTestName/<tempdir>.
+		prefix := filepath.Join(outDir, "_artifacts/flumetest/NiceTestName") + string(filepath.Separator)
+		assert.True(t, strings.HasPrefix(dir, prefix),
+			"expected dir %q to start with %q", dir, prefix)
+	})
+
+	t.Run("consecutive_calls_return_same_dir", func(t *testing.T) {
+		setArtifactsFlag(t)
+		setOutputDir(t)
+
+		m := &mockTOldGo{name: "TestGetArtifactDir/consecutive"}
+		dir1, ok1 := getArtifactDir(m)
+		require.True(t, ok1)
+
+		dir2, ok2 := getArtifactDir(m)
+		require.True(t, ok2)
+
+		assert.Equal(t, dir1, dir2, "expected consecutive calls to return the same directory")
+	})
+}
+
+// TestStartOldGo covers the Start() paths that are only reached on pre-go1.26:
+// routing logs to an artifact file, reporting the artifact dir on failure/panic,
+// and staying quiet on success.
+func TestStartOldGo(t *testing.T) {
+	var log = flume.New("TestStartOldGo")
+
+	// Restore Verbose/Disabled after each sub-test (Start reads them).
+	setup := func(t *testing.T) {
+		t.Helper()
+
+		oldV, oldD := Verbose(), Disabled()
+
+		t.Cleanup(func() { SetVerbose(oldV); SetDisabled(oldD) })
+	}
+
+	t.Run("failure_logs_artifacts_path_to_tlog", func(t *testing.T) {
+		setup(t)
+		setArtifactsFlag(t)
+		outDir := setOutputDir(t)
+
+		m := &mockTOldGo{mockT: mockT{failed: true}, name: "TestStartOldGo/failure"}
+		revert := Start(m)
+
+		log.Info("failure log message", "color", "red")
+		revert()
+
+		// On failure the artifact directory path is reported via t.Log.
+		assert.Contains(t, m.logs.String(), "=== ARTIFACTS")
+		assert.Contains(t, m.logs.String(), "TestStartOldGo/failure")
+
+		// The log message itself goes to the artifact file, not t.Log.
+		assert.NotContains(t, m.logs.String(), "color=red")
+
+		// Verify the artifact file exists and contains the log message.
+		logFile := findArtifactLogRecursive(t, outDir)
+		data, err := os.ReadFile(logFile)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "color=red")
+	})
+
+	t.Run("success_no_artifacts_created", func(t *testing.T) {
+		setup(t)
+		setArtifactsFlag(t)
+		outDir := setOutputDir(t)
+
+		m := &mockTOldGo{name: "TestStartOldGo/success"}
+		revert := Start(m)
+
+		log.Info("success message", "taste", "sweet")
+		revert()
+
+		// No "=== ARTIFACTS" line on a passing test.
+		assert.NotContains(t, m.logs.String(), "=== ARTIFACTS")
+
+		// Logs are discarded on success, not sent to t.Log.
+		assert.NotContains(t, m.logs.String(), "taste=sweet")
+
+		// No artifact file should be created on a passing test.
+		assertNoArtifactLogs(t, outDir)
+	})
+
+	t.Run("verbose_success_saves_artifacts", func(t *testing.T) {
+		setup(t)
+		SetVerbose(true)
+		setArtifactsFlag(t)
+		outDir := setOutputDir(t)
+
+		m := &mockTOldGo{name: "TestStartOldGo/verbose_success"}
+		revert := Start(m)
+
+		log.Info("verbose success message", "flavor", "umami")
+		revert()
+
+		// Verbose + artifacts: logs go to file, not t.Log.
+		assert.NotContains(t, m.logs.String(), "flavor=umami")
+		assert.Contains(t, m.logs.String(), "=== ARTIFACTS "+m.name)
+
+		// Artifact file should exist and contain the log.
+		logFile := findArtifactLogRecursive(t, outDir)
+		data, err := os.ReadFile(logFile)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "flavor=umami")
+	})
+
+	t.Run("panic_logs_artifacts_path_to_tlog", func(t *testing.T) {
+		setup(t)
+		setArtifactsFlag(t)
+		setOutputDir(t)
+
+		m := &mockTOldGo{name: "TestStartOldGo/panic"}
+
+		require.Panics(t, func() {
+			defer Start(m)()
+
+			log.Info("panic message", "shape", "circle")
+			panic("boom")
+		})
+
+		// A panic should also trigger the "=== ARTIFACTS" diagnostic.
+		assert.Contains(t, m.logs.String(), "=== ARTIFACTS")
+		// The log message went to the file, not t.Log.
+		assert.NotContains(t, m.logs.String(), "shape=circle")
+	})
+
+	t.Run("artifacts_path_written_to_output_when_available", func(t *testing.T) {
+		setup(t)
+		setArtifactsFlag(t)
+		setOutputDir(t)
+
+		m := &mockTOldGoWithOutput{mockTOldGo: mockTOldGo{
+			mockT: mockT{failed: true},
+			name:  "TestStartOldGo/output",
+		}}
+		revert := Start(m)
+
+		log.Info("output path message", "key", "val")
+		revert()
+
+		// The "=== ARTIFACTS" diagnostic should go to Output(), not t.Log().
+		assert.Contains(t, m.output.String(), "=== ARTIFACTS")
+		assert.Contains(t, m.output.String(), "TestStartOldGo/output")
+		assert.NotContains(t, m.logs.String(), "=== ARTIFACTS")
+	})
+}
+
+func TestRelArtifactBase(t *testing.T) {
+	tests := []struct {
+		desc        string
+		name        string
+		buildInfo   *debug.BuildInfo
+		buildInfoOk bool
+		expected    string
+	}{
+		{
+			desc:        "nice name",
+			name:        "NiceTestName",
+			buildInfoOk: false,
+			expected:    filepath.Join("unknown", "NiceTestName"),
+		},
+		{
+			desc:        "sub test name",
+			name:        "TestName/sub_Test",
+			buildInfoOk: false,
+			expected:    filepath.Join("unknown", "TestName__sub_Test"),
+		},
+		{
+			desc:        "long name",
+			name:        strings.Repeat("a", 80),
+			buildInfoOk: false,
+			expected:    filepath.Join("unknown", strings.Repeat("a", 64-16)+fmt.Sprintf("%0x", hashName(strings.Repeat("a", 80)))),
+		},
+		{
+			desc:        "name with invalid chars",
+			name:        "Test_*?<>|Name",
+			buildInfoOk: false,
+			expected:    filepath.Join("unknown", "Test_Name"),
+		},
+		{
+			desc: "test is in root package of module (no pkg path segment)",
+			name: "NiceTestName",
+			buildInfo: &debug.BuildInfo{
+				Path: "github.com/example/mod.test",
+				Main: debug.Module{Path: "github.com/example/mod"},
+			},
+			buildInfoOk: true,
+			expected:    "NiceTestName",
+		},
+		{
+			desc: "test is in package one level deep",
+			name: "NiceTestName",
+			buildInfo: &debug.BuildInfo{
+				Path: "github.com/example/mod/pkg.test",
+				Main: debug.Module{Path: "github.com/example/mod"},
+			},
+			buildInfoOk: true,
+			expected:    filepath.Join("pkg", "NiceTestName"),
+		},
+		{
+			desc: "test is in package multiple levels deep",
+			name: "NiceTestName",
+			buildInfo: &debug.BuildInfo{
+				Path: "github.com/example/mod/pkg/subpkg/deep.test",
+				Main: debug.Module{Path: "github.com/example/mod"},
+			},
+			buildInfoOk: true,
+			expected:    filepath.Join("pkg", "subpkg", "deep", "NiceTestName"),
+		},
+		{
+			desc:        "package is unknown",
+			name:        "NiceTestName",
+			buildInfo:   nil,
+			buildInfoOk: false,
+			expected:    filepath.Join("unknown", "NiceTestName"),
+		},
+		{
+			desc:        "file name can't be made valid (should return empty)",
+			name:        "..",
+			buildInfoOk: false,
+			expected:    "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			m := &mockTOldGo{name: tc.name}
+
+			readBuildInfo := func() (*debug.BuildInfo, bool) {
+				return tc.buildInfo, tc.buildInfoOk
+			}
+			result := relArtifactBase(m, readBuildInfo)
+
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/v2/flumetest/flumetest_test.go
+++ b/v2/flumetest/flumetest_test.go
@@ -2,7 +2,10 @@ package flumetest
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -47,7 +50,11 @@ func (m *mockT) Log(args ...any) {
 	m.Lock()
 	defer m.Unlock()
 
-	_, _ = fmt.Fprint(&m.logs, args...)
+	_, _ = fmt.Fprintln(&m.logs, args...)
+}
+
+func (m *mockT) Name() string {
+	return "TestSomething"
 }
 
 func TestStart(t *testing.T) {
@@ -201,6 +208,137 @@ func TestStart(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStartArtifacts(t *testing.T) {
+	var log = flume.New("TestStartArtifacts")
+
+	// Save and restore original state
+	oldDisabled := Disabled()
+	oldVerbose := Verbose()
+
+	defer func() {
+		SetDisabled(oldDisabled)
+		SetVerbose(oldVerbose)
+	}()
+
+	t.Run("success_no_artifact_file", func(t *testing.T) {
+		dir := t.TempDir()
+		setArtifactsFlag(t)
+
+		m := &mockTWithArtifacts{mockT: mockT{}, artifactDir: dir}
+		revert := Start(m)
+
+		log.Info("artifact test message", "key", "val")
+		revert()
+
+		// On success, no artifact file should be created.
+		matches, err := filepath.Glob(filepath.Join(dir, "flumetest_*.log"))
+		require.NoError(t, err)
+		assert.Empty(t, matches, "no artifact log file expected on success")
+		assert.Empty(t, m.logs.String())
+	})
+
+	t.Run("verbose_writes_to_file_on_success", func(t *testing.T) {
+		dir := t.TempDir()
+		setArtifactsFlag(t)
+		SetVerbose(true)
+
+		m := &mockTWithArtifacts{mockT: mockT{}, artifactDir: dir}
+		revert := Start(m)
+
+		log.Info("verbose artifact message", "key", "val")
+		revert()
+
+		// Verbose + artifacts: logs go to file, not t.Log.
+		data, err := os.ReadFile(findArtifactLog(t, dir))
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "key=val")
+		assert.Empty(t, m.logs.String())
+	})
+
+	t.Run("no_tlog_output_on_failure", func(t *testing.T) {
+		dir := t.TempDir()
+		setArtifactsFlag(t)
+
+		m := &mockTWithArtifacts{mockT: mockT{failed: true}, artifactDir: dir}
+		revert := Start(m)
+
+		log.Info("should go to file", "color", "blue")
+		revert()
+
+		data, err := os.ReadFile(findArtifactLog(t, dir))
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "color=blue")
+		assert.Empty(t, m.logs.String())
+	})
+
+	t.Run("panic_is_repanicked", func(t *testing.T) {
+		dir := t.TempDir()
+		setArtifactsFlag(t)
+
+		m := &mockTWithArtifacts{mockT: mockT{}, artifactDir: dir}
+
+		require.Panics(t, func() {
+			defer Start(m)()
+
+			log.Info("artifact panic message", "key", "val")
+
+			panic("boom")
+		})
+	})
+}
+
+func TestArtifactsEnabled(t *testing.T) {
+	// Clean up any flags we register during the test.
+	// We can't unregister flags, so we test with fresh names via Lookup behavior.
+	t.Run("not_set", func(t *testing.T) {
+		clearArtifactsFlag(t)
+		assert.False(t, artifactsEnabled())
+	})
+
+	t.Run("artifacts_flag", func(t *testing.T) {
+		setArtifactsFlag(t)
+		assert.True(t, artifactsEnabled())
+	})
+}
+
+// findArtifactLog returns the path of the single log file written into the
+// flumetest subdirectory of dir.  It fails the test if there isn't exactly one.
+func findArtifactLog(t *testing.T, dir string) string {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(dir, "flumetest_*.log"))
+	require.NoError(t, err)
+	require.Len(t, matches, 1, "expected exactly one artifact log file in %s", dir)
+
+	return matches[0]
+}
+
+// setArtifactsFlag enables whichever artifacts flag is registered.
+func setArtifactsFlag(t *testing.T) {
+	t.Helper()
+
+	for _, name := range []string{"test.artifacts", "artifacts"} {
+		if f := flag.CommandLine.Lookup(name); f != nil {
+			require.NoError(t, flag.CommandLine.Set(name, "true"))
+			t.Cleanup(func() { _ = flag.CommandLine.Set(name, "false") })
+
+			return
+		}
+	}
+
+	t.Fatal("no artifacts flag found")
+}
+
+type mockTWithArtifacts struct {
+	mockT
+
+	artifactDir string
+}
+
+func (m *mockTWithArtifacts) ArtifactDir() string {
+	return m.artifactDir
 }
 
 func TestSnapshot(t *testing.T) {

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,8 +1,8 @@
 module github.com/ThalesGroup/flume/v2
 
-go 1.21
+go 1.24
 
-toolchain go1.23.4
+toolchain go1.24.10
 
 require (
 	github.com/ansel1/console-slog v0.6.0


### PR DESCRIPTION
Supports the new -artifacts flag in go1.26: if set, logs for each test will be saved to $artifactDir/flumetest/flumetest_<timestamp>.log

It also backfills `-artifacts` flag for older versions of go, so you can start using `go test -artifacts` before upgrading to go1.26.

The artifact dir defaults to $outputDir (another test flag), which defaults to cwd.

If `-artifacts` is not set, logs are inlined in the test log as usual.